### PR TITLE
added a reconnect configuration for ability to reconnect before each test

### DIFF
--- a/src/Codeception/Module/AMQP.php
+++ b/src/Codeception/Module/AMQP.php
@@ -31,6 +31,7 @@ use PhpAmqpLib\Message\AMQPMessage;
  * * cleanup: true - defined queues will be purged before running every test.
  * * queues: [mail, twitter] - queues to cleanup
  * * single_channel - create and use only one channel during test execution
+ * * reconnect - reconnects before each test to drop unused open channels
  *
  * ### Example
  *
@@ -44,6 +45,7 @@ use PhpAmqpLib\Message\AMQPMessage;
  *                 vhost: '/'
  *                 queues: [queue1, queue2]
  *                 single_channel: false
+ *                 reconnect: false
  *
  * ## Public Properties
  *
@@ -59,6 +61,7 @@ class AMQP extends Module implements RequiresPackage
         'vhost'          => '/',
         'cleanup'        => true,
         'single_channel' => false,
+        'reconnect'      => false,
         'queues'         => []
     ];
 
@@ -95,6 +98,10 @@ class AMQP extends Module implements RequiresPackage
     {
         if ($this->config['cleanup']) {
             $this->cleanup();
+        }
+
+        if ($this->config['reconnect']) {
+            $this->getChannel()->getConnection()->reconnect();
         }
     }
 


### PR DESCRIPTION
I came across a situation where, while running a huge number of tests with queues, they started to crash. If you do not use the single_channel option, then the number of open channels will overflow and the corresponding error will appear. If you use it, then for some reason an error begins to appear stating that it is not possible to create an exchange or queue. I was able to overcome this problem by adding a reconnect before each test next to the cleanup, thereby deleting all previous unused channels.