### PR TITLE
Explicitly declare parameter types as nullable

### DIFF
--- a/src/Codeception/Module/AMQP.php
+++ b/src/Codeception/Module/AMQP.php
@@ -109,7 +109,7 @@ class AMQP extends Module implements RequiresPackage
      * $I->pushToExchange('exchange.emails', new AMQPMessage('Thanks!'), 'severity');
      * ```
      */
-    public function pushToExchange(string $exchange, string|AMQPMessage $message, string $routing_key = null): void
+    public function pushToExchange(string $exchange, string|AMQPMessage $message, ?string $routing_key = null): void
     {
         $message = $message instanceof AMQPMessage
             ? $message
@@ -159,8 +159,8 @@ class AMQP extends Module implements RequiresPackage
         bool $auto_delete = true,
         bool $internal = false,
         bool $nowait = false,
-        array $arguments = null,
-        int $ticket = null
+        ?array $arguments = null,
+        ?int $ticket = null
     ) {
         return $this->getChannel()->exchange_declare(
             $exchange,
@@ -196,8 +196,8 @@ class AMQP extends Module implements RequiresPackage
         bool $exclusive = false,
         bool $auto_delete = true,
         bool $nowait = false,
-        array $arguments = null,
-        int $ticket = null
+        ?array $arguments = null,
+        ?int $ticket = null
     ): ?array {
         return $this->getChannel()->queue_declare(
             $queue,
@@ -232,8 +232,8 @@ class AMQP extends Module implements RequiresPackage
         string $exchange,
         string $routing_key = '',
         bool $nowait = false,
-        array $arguments = null,
-        int $ticket = null
+        ?array $arguments = null,
+        ?int $ticket = null
     ) {
         return $this->getChannel()->queue_bind(
             $queue,


### PR DESCRIPTION
Starting with PHP 8.4, implicit nullability triggers a deprecation warning. See https://wiki.php.net/rfc/deprecate-implicitly-nullable-types. Excerpt from the logs

```
Deprecated: Codeception\Module\AMQP::pushToExchange(): Implicitly marking parameter $routing_key as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/codeception/module-amqp/src/Codeception/Module/AMQP.php on line 112

Deprecated: Codeception\Module\AMQP::declareExchange(): Implicitly marking parameter $arguments as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/codeception/module-amqp/src/Codeception/Module/AMQP.php on line 154

Deprecated: Codeception\Module\AMQP::declareExchange(): Implicitly marking parameter $ticket as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/codeception/module-amqp/src/Codeception/Module/AMQP.php on line 154

Deprecated: Codeception\Module\AMQP::declareQueue(): Implicitly marking parameter $arguments as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/codeception/module-amqp/src/Codeception/Module/AMQP.php on line 192

Deprecated: Codeception\Module\AMQP::declareQueue(): Implicitly marking parameter $ticket as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/codeception/module-amqp/src/Codeception/Module/AMQP.php on line 192

Deprecated: Codeception\Module\AMQP::bindQueueToExchange(): Implicitly marking parameter $arguments as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/codeception/module-amqp/src/Codeception/Module/AMQP.php on line 230

Deprecated: Codeception\Module\AMQP::bindQueueToExchange(): Implicitly marking parameter $ticket as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/codeception/module-amqp/src/Codeception/Module/AMQP.php on line 230
```